### PR TITLE
实现 correctTagsOffset 方法

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -749,6 +749,13 @@ func (pc *pushConsumer) sendMessageBack(brokerName string, msg *primitive.Messag
 	}
 	_, err := pc.client.InvokeSync(context.Background(), brokerAddr, pc.buildSendBackRequest(msg, delayLevel), 3*time.Second)
 	if err != nil {
+		rlog.Error("sendMessageBack err", map[string]interface{}{
+			"msg":        msg,
+			"brokerName": brokerName,
+			"delayLevel": delayLevel,
+			"brokerAddr": brokerAddr,
+			"err":        err.Error(),
+		})
 		return false
 	}
 	return true

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -516,7 +516,7 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 		}
 
 		cachedMessageSizeInMiB := int(pq.cachedMsgSize / Mb)
-		if pq.cachedMsgCount > pc.option.PullThresholdForQueue {
+		if atomic.LoadInt64(&pq.cachedMsgCount) > pc.option.PullThresholdForQueue {
 			if pc.queueFlowControlTimes%1000 == 0 {
 				rlog.Warning("the cached message count exceeds the threshold, so do flow control", map[string]interface{}{
 					"PullThresholdForQueue": pc.option.PullThresholdForQueue,

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -730,6 +730,16 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 
 func (pc *pushConsumer) correctTagsOffset(pr *PullRequest) {
 	if atomic.LoadInt64(&pr.pq.cachedMsgCount) == 0 {
+		if pr.pq.IsDroppd() {
+			return
+		}
+		if !pr.pq.IsLock() {
+			return
+		}
+		if pr.pq.isLockExpired() {
+			return
+		}
+
 		rlog.Info("request msgCount is 0", map[string]interface{}{
 			rlog.LogKeyPullRequest: pr.String(),
 		})

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -746,12 +746,12 @@ func (pc *pushConsumer) sendMessageBack(brokerName string, msg *primitive.Messag
 	}
 	_, err := pc.client.InvokeSync(context.Background(), brokerAddr, pc.buildSendBackRequest(msg, delayLevel), 3*time.Second)
 	if err != nil {
-		rlog.Error("sendMessageBack err", map[string]interface{}{
-			"msg":        msg,
-			"brokerName": brokerName,
-			"delayLevel": delayLevel,
-			"brokerAddr": brokerAddr,
-			"err":        err.Error(),
+		rlog.Error("send message back err", map[string]interface{}{
+			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyMessageQueue:  msg.Queue.String(),
+			rlog.LogKeyConsumerGroup: pc.consumerGroup,
+			"brokerAddr":             brokerAddr,
+			"msgID":                  msg.MsgId,
 		})
 		return false
 	}

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -455,9 +455,10 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 	})
 	var sleepTime time.Duration
 	pq := request.pq
-	var done = make(chan struct{})
-	defer close(done)
-
+	var done = make(chan struct{}, 1)
+	defer func() {
+		done <- struct{}{}
+	}()
 	go primitive.WithRecover(func() {
 		for {
 			select {

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -455,16 +455,12 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 	})
 	var sleepTime time.Duration
 	pq := request.pq
-	var done = make(chan struct{}, 1)
-	defer func() {
-		done <- struct{}{}
-	}()
 	go primitive.WithRecover(func() {
 		for {
 			select {
-			case <-done:
-				rlog.Debug("pullMessage quited, so stop task", map[string]interface{}{
-					rlog.LogKeyPullRequest: request.String(),
+			case <-pc.done:
+				rlog.Info("push consumer close pullMessage.", map[string]interface{}{
+					rlog.LogKeyConsumerGroup: pc.consumerGroup,
 				})
 				return
 			default:


### PR DESCRIPTION
修复mq在少量消息的情况下，消息大量挤压的问题


另外尽量减少和上游的差异。最后应该是可以直接使用上游